### PR TITLE
use make_shared

### DIFF
--- a/examples/cpp/shared_ptr.cpp
+++ b/examples/cpp/shared_ptr.cpp
@@ -23,7 +23,10 @@ public:
 	// to a private ctor - we use this to create objects
 	template<typename ... T>
 	static std::shared_ptr<SharedThing> create(T&& ... t) {
-		return std::shared_ptr<SharedThing>(new SharedThing(std::forward<T>(t)...));
+		struct EnableMakeShared : public SharedThing {
+			EnableMakeShared(Arg&&... arg) : SharedThing(std::forward<Arg>(arg)...) {}
+		};
+		return std::make_shared<EnableMakeShared>(std::forward<Arg>(arg)...);
 	}
 
 private:


### PR DESCRIPTION
# Pull Request Template

## Description
C++ Core Guidelines
C.151: Use make_shared() to construct objects owned by shared_ptrs.

Fixes # (issue)

## How Has This Been Tested?

GCC9.2.0.

- [ ] Test build and run.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
