### PR TITLE
defrag_free_list updated the last block size

### DIFF
--- a/examples/c/malloc/malloc_freelist.c
+++ b/examples/c/malloc/malloc_freelist.c
@@ -58,7 +58,7 @@ void defrag_free_list(void)
 		{
 			if((((uintptr_t)&last_block->block) + last_block->size) == (uintptr_t)block)
 			{
-				last_block->size += sizeof(*block) + block->size;
+				last_block->size += ALLOC_HEADER_SZ + block->size;
 				list_del(&block->node);
 				continue;
 			}


### PR DESCRIPTION
In the function defrag_free_list ,last block size should add the ALLOC_HEADER_SZ instead of sizeof(*block)


## Description

Updated the last block_size properly in the defrag_free_list function. Freelist does not return to its original state after subsequent mallocs and frees. 

e.g. ptr1 = fl_malloc(100), ptr2 =  fl_malloc(4*1024), f1_free(ptr1), f1_free(ptr2) . Freelist does not return to its original state.  

Fixes # (issue)

Freelist does not return to its original state after subsequent mallocs and frees. Update the last block size properly to fix the same.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Test A
`
void* my_block = malloc(MALLOC_SIZE); // For host system demonstration, alloc 4MB block

	printf("Allocated a block on the host, pointer: %p, size %d\n", my_block, MALLOC_SIZE);

	// Initialize our simple freelist with the space.
	// On our embedded platform, this will be the RAM address for your pool and the size you desire.
	malloc_addblock(my_block, MALLOC_SIZE);
void* t1 = fl_malloc(100);
	printf("Malloc'd from free list: %p\n", t1);

	void* t2 = fl_malloc(4 * 1024);
	printf("Malloc'd from free list: %p\n", t2);

	printf("Putting first pointer back into the pool\n");
	fl_free(t1), t1 = NULL;

	printf("Putting 2nd pointer back into the pool\n");
	fl_free(t2), t2 = NULL;
`
After the defrag_free_list function call, we can traverse the freelist to check its state. Earlier the freelist was not returning to its original state. With the proposed change, freelist returns to its original state after f1_mallocs and f1_frees. 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
