### PR TITLE
Freelist malloc bugfix. 

### DIFF
--- a/examples/libc/malloc_freelist.c
+++ b/examples/libc/malloc_freelist.c
@@ -59,7 +59,7 @@ void defrag_free_list(void)
 		{
 			if((((uintptr_t)&lb->block) + lb->size) == (uintptr_t)b)
 			{
-				lb->size += sizeof(*b) + b->size;
+				lb->size += ALLOC_HEADER_SZ + b->size;
 				list_del(&b->node);
 				continue;
 			}


### PR DESCRIPTION
# Pull Request Template

## Description

Block size was increased by an extra 8 bytes when the defragmentation function merged two blocks.

Fixes #54 

## How Has This Been Tested?

Malloc heavy test program while printing the freelist before and after each malloc and free.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
